### PR TITLE
Bug fix when values are zero

### DIFF
--- a/src/app/boom/BoomSeriesUtils.ts
+++ b/src/app/boom/BoomSeriesUtils.ts
@@ -125,7 +125,7 @@ export let getCurrentTimeStamp = function (dataPoints: any[]): Date {
 };
 export let doesValueNeedsToHide = function (value: number, filter: any): boolean {
     let hidden = false;
-    if (value && filter && (filter.value_below !== "" || filter.value_above !== "")) {
+    if ((value || value==0) && filter && (filter.value_below !== "" || filter.value_above !== "")) {
         if (filter.value_below !== "" && value < +(filter.value_below)) {
             hidden = true;
         }


### PR DESCRIPTION
When hiding values below a positive number, zero values are not hidden.  The conditional for the if statement was updated to include a zero value.