### PR TITLE
fix: bug with series.dataPoints

### DIFF
--- a/src/app/boom/BoomSeries.ts
+++ b/src/app/boom/BoomSeries.ts
@@ -41,7 +41,7 @@ class BoomSeries implements IBoomSeries {
 
         this.debug_mode = options && options.debug_mode === true ? true : false;
         this.row_col_wrapper = options && options.row_col_wrapper ? options.row_col_wrapper : this.row_col_wrapper;
-        this.currentTimeStamp = getCurrentTimeStamp(series.dataPoints);
+        this.currentTimeStamp = getCurrentTimeStamp(series.datapoints);
         this.seriesName = series.alias || series.aliasEscaped || series.label || series.id || "";
 
         let getMatchingAndEnabledPattern = (patterns, seriesName) => patterns.find(p => seriesName.match(p.pattern) && p.disabled !== true);


### PR DESCRIPTION
There is no field `series.dataPoints` on `TimeSeries` instance

Please point me out if changes to `dist` also required in PR (maybe you change it only before release)