### PR TITLE
Fix error while rendering panel as image

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -176,6 +176,7 @@ GrafanaBoomTableCtrl.prototype.render = function () {
       boundary: 'scrollParent',
     });
     this.adjustScrollBar();
+    this.renderingCompleted();
   }
 };
 


### PR DESCRIPTION
This PR fixes #18 by adding `this.renderingCompleted()` to satisfy the image renderer.