### PR TITLE
#154 Allow current stat value to be zero

### DIFF
--- a/src/app/boom/BoomUtils.ts
+++ b/src/app/boom/BoomUtils.ts
@@ -186,7 +186,7 @@ export const getSeriesValue = function (series: any, statType: string): number {
         value = _.last(non_null_data)[1];
       }
     } else if (series.stats) {
-      value = series.stats[statType] || null;
+      value = series.stats[statType] !== undefined ? series.stats[statType] : null;
     }
   }
   return value;

--- a/src/tests/BoomSeries.spec.ts
+++ b/src/tests/BoomSeries.spec.ts
@@ -75,6 +75,7 @@ describe("Boom Series", () => {
         expect(getSeriesValue({}, "total")).toBe(NaN);
         expect(getSeriesValue({}, "foo")).toBe(NaN);
         expect(getSeriesValue(dummy_series_1, "foo")).toBe(null);
+        expect(getSeriesValue(dummy_series_1, "current")).toBe(6);
         expect(getSeriesValue(dummy_series_1, "total")).toBe(3268);
         expect(getSeriesValue(dummy_series_1, "TOTAL")).toBe(3268);
         expect(getSeriesValue(dummy_series_1, "last_time")).toBe(null);
@@ -82,6 +83,7 @@ describe("Boom Series", () => {
         expect(getSeriesValue(dummy_series_2, "total")).toBe(dummy_series_2.stats.total);
         expect(getSeriesValue(dummy_series_2, "last_time_nonnull")).toBe(1575199020000);
         expect(getSeriesValue(dummy_series_2, "last_time")).toBe(1575199260000);
+        expect(getSeriesValue(dummy_series_2, "current")).toBe(0);
     });
     it("getCurrentTimeStamp", () => {
         expect(getCurrentTimeStamp(dummy_series_2.datapoints)).toStrictEqual(new Date(1575199260000));


### PR DESCRIPTION
Fixes #154. The value of a stat can be zero, yet the || statement will resolve to null if the value is 0. The change now sets the value to be null only if the stat value is undefined.