### PR TITLE
Bug Fix for PIG-1075

### DIFF
--- a/src/css/_boomtable.scss
+++ b/src/css/_boomtable.scss
@@ -20,6 +20,13 @@
     }
 }
 
+#boomtable_output_body_headers th{
+    position: sticky;
+    top: 0;
+    color: rgb(51, 162, 229);
+    background-color: rgb(32, 34, 38);;
+}
+
 .boom-table .debug {
     margin-top: 30px;
 }


### PR DESCRIPTION
This commit makes the table headers sticky so that when a user scrolls on a table, they have context for what species is being described in a given column.